### PR TITLE
fix: stale snapshot query

### DIFF
--- a/packages/react-kitchen-sink/src/react-query/FirestoreSnapshotManager.ts
+++ b/packages/react-kitchen-sink/src/react-query/FirestoreSnapshotManager.ts
@@ -59,6 +59,8 @@ export class FirestoreSnapshotManager {
     })
   }
 
+  isSnapshotAlive = (queryKey: QueryKey) => this.#onClose.has(hashKey(queryKey))
+
   registerSnapshotOnClose = (queryKey: QueryKey, onCloseSnapshot: () => void) => {
     const snapshotId = hashKey(queryKey)
     const closeSnapshot = this.#onClose.get(snapshotId)

--- a/packages/react-kitchen-sink/src/react-query/__tests__/FirestoreSnapshotManager.test.ts
+++ b/packages/react-kitchen-sink/src/react-query/__tests__/FirestoreSnapshotManager.test.ts
@@ -149,4 +149,22 @@ describe('FirestoreSnapshotManager', () => {
     const messageArg = vi.mocked(captureMessage).mock.calls.at(-1)?.[0]
     expect(String(messageArg)).toMatch(/Subscription for key/)
   })
+
+  it('isSnapshotAlive returns true for registered snapshots', () => {
+    const manager = new FirestoreSnapshotManager(queryClient)
+    const ref = mock<DocumentReference>({ id: 'doc' })
+    const queryKey = ['test']
+
+    // Register a snapshot
+    manager.documentSnapshotSubjectFactory(ref)(queryKey)
+
+    expect(manager.isSnapshotAlive(queryKey)).toBe(true)
+  })
+
+  it('isSnapshotAlive returns false for unregistered snapshots', () => {
+    const manager = new FirestoreSnapshotManager(queryClient)
+    const queryKey = ['unregistered']
+
+    expect(manager.isSnapshotAlive(queryKey)).toBe(false)
+  })
 })

--- a/packages/react-kitchen-sink/src/react-query/__tests__/documentSnapshotQueryOptions.test.ts
+++ b/packages/react-kitchen-sink/src/react-query/__tests__/documentSnapshotQueryOptions.test.ts
@@ -19,4 +19,24 @@ describe('documentSnapshotQueryOptions', () => {
     expect(snapshotManager.documentSnapshotSubjectFactory).toHaveBeenCalledWith(ref, snapshotOptions, listener)
     expect(opts.meta?.type).toBe('snapshot')
   })
+
+  it('sets staleTime to static when snapshot is alive', () => {
+    const snapshotManager = mock<FirestoreSnapshotManager>()
+    snapshotManager.isSnapshotAlive.mockReturnValue(true)
+    const ref = mock<DocumentReference>({ id: 'r' })
+    const opts = documentSnapshotQueryOptions(snapshotManager, { ref, queryKey: ['k'] })
+
+    expect(typeof opts.staleTime).toBe('function')
+    expect((opts.staleTime as () => string | number)()).toBe('static')
+  })
+
+  it('sets staleTime to 0 when snapshot is not alive', () => {
+    const snapshotManager = mock<FirestoreSnapshotManager>()
+    snapshotManager.isSnapshotAlive.mockReturnValue(false)
+    const ref = mock<DocumentReference>({ id: 'r' })
+    const opts = documentSnapshotQueryOptions(snapshotManager, { ref, queryKey: ['k'] })
+
+    expect(typeof opts.staleTime).toBe('function')
+    expect((opts.staleTime as () => string | number)()).toBe(0)
+  })
 })

--- a/packages/react-kitchen-sink/src/react-query/__tests__/querySnapshotQueryOptions.test.ts
+++ b/packages/react-kitchen-sink/src/react-query/__tests__/querySnapshotQueryOptions.test.ts
@@ -19,4 +19,24 @@ describe('querySnapshotQueryOptions', () => {
     expect(snapshotManager.querySnapshotSubjectFactory).toHaveBeenCalledWith(query, snapshotOptions, listener)
     expect(opts.meta?.type).toBe('snapshot')
   })
+
+  it('sets staleTime to static when snapshot is alive', () => {
+    const snapshotManager = mock<FirestoreSnapshotManager>()
+    snapshotManager.isSnapshotAlive.mockReturnValue(true)
+    const query = mock<Query>()
+    const opts = querySnapshotQueryOptions(snapshotManager, { query, queryKey: ['k'] })
+
+    expect(typeof opts.staleTime).toBe('function')
+    expect((opts.staleTime as () => string | number)()).toBe('static')
+  })
+
+  it('sets staleTime to 0 when snapshot is not alive', () => {
+    const snapshotManager = mock<FirestoreSnapshotManager>()
+    snapshotManager.isSnapshotAlive.mockReturnValue(false)
+    const query = mock<Query>()
+    const opts = querySnapshotQueryOptions(snapshotManager, { query, queryKey: ['k'] })
+
+    expect(typeof opts.staleTime).toBe('function')
+    expect((opts.staleTime as () => string | number)()).toBe(0)
+  })
 })

--- a/packages/react-kitchen-sink/src/react-query/__tests__/schemaQuerySnapshotQueryOptions.test.ts
+++ b/packages/react-kitchen-sink/src/react-query/__tests__/schemaQuerySnapshotQueryOptions.test.ts
@@ -39,4 +39,30 @@ describe('schemaQuerySnapshotQueryOptions', () => {
     )
     expect(opts.meta?.type).toBe('snapshot')
   })
+
+  it('sets staleTime to static when snapshot is alive', () => {
+    const snapshotManager = mock<FirestoreSnapshotManager>()
+    snapshotManager.isSnapshotAlive.mockReturnValue(true)
+    const opts = schemaQuerySnapshotQueryOptions(snapshotManager, {
+      factory: collections.users,
+      query: { name: 'q' },
+      queryKey: ['k'],
+    })
+
+    expect(typeof opts.staleTime).toBe('function')
+    expect((opts.staleTime as () => string | number)()).toBe('static')
+  })
+
+  it('sets staleTime to 0 when snapshot is not alive', () => {
+    const snapshotManager = mock<FirestoreSnapshotManager>()
+    snapshotManager.isSnapshotAlive.mockReturnValue(false)
+    const opts = schemaQuerySnapshotQueryOptions(snapshotManager, {
+      factory: collections.users,
+      query: { name: 'q' },
+      queryKey: ['k'],
+    })
+
+    expect(typeof opts.staleTime).toBe('function')
+    expect((opts.staleTime as () => string | number)()).toBe(0)
+  })
 })

--- a/packages/react-kitchen-sink/src/react-query/documentSnapshotQueryOptions.ts
+++ b/packages/react-kitchen-sink/src/react-query/documentSnapshotQueryOptions.ts
@@ -69,7 +69,7 @@ export const documentSnapshotQueryOptions = <
       snapshotManager.documentSnapshotSubjectFactory(ref, snapshotOptions, listener),
       props,
     ),
-    staleTime: Infinity,
+    staleTime: () => (snapshotManager.isSnapshotAlive(props.queryKey) ? 'static' : 0),
     retry: false,
     gcTime: 10_000,
     ...props,

--- a/packages/react-kitchen-sink/src/react-query/observers/__tests__/documentSnapshotQueryClientObserver.test.ts
+++ b/packages/react-kitchen-sink/src/react-query/observers/__tests__/documentSnapshotQueryClientObserver.test.ts
@@ -1,3 +1,4 @@
+import { addBreadcrumb } from '@sentry/react'
 import { type QueryClient } from '@tanstack/react-query'
 import { type DocumentSnapshotState } from '@valian/rxjs-firebase'
 import { describe, expect, it, vi } from 'vitest'
@@ -5,7 +6,10 @@ import { mock } from 'vitest-mock-extended'
 
 import { documentSnapshotQueryClientObserver } from '../documentSnapshotQueryClientObserver'
 
-vi.mock('@sentry/react', () => ({ captureException: vi.fn() }))
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}))
 
 describe('documentSnapshotQueryClientObserver', () => {
   it('sets data on next, error and complete', () => {
@@ -24,10 +28,12 @@ describe('documentSnapshotQueryClientObserver', () => {
     })
 
     observer.complete()
-    expect(client.setQueryData).toHaveBeenCalledWith(queryKey, {
-      isLoading: false,
-      hasError: false,
-      disabled: true,
+    expect(addBreadcrumb).toHaveBeenCalledWith({
+      level: 'debug',
+      message: 'Query snapshot query completed',
+      data: {
+        queryKey,
+      },
     })
   })
 })

--- a/packages/react-kitchen-sink/src/react-query/observers/__tests__/querySnapshotQueryClientObserver.test.ts
+++ b/packages/react-kitchen-sink/src/react-query/observers/__tests__/querySnapshotQueryClientObserver.test.ts
@@ -1,3 +1,4 @@
+import { addBreadcrumb } from '@sentry/react'
 import { type QueryClient } from '@tanstack/react-query'
 import { type QuerySnapshotState } from '@valian/rxjs-firebase'
 import { describe, expect, it, vi } from 'vitest'
@@ -5,7 +6,10 @@ import { mock } from 'vitest-mock-extended'
 
 import { querySnapshotQueryClientObserver } from '../querySnapshotQueryClientObserver'
 
-vi.mock('@sentry/react', () => ({ captureException: vi.fn() }))
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}))
 
 describe('querySnapshotQueryClientObserver', () => {
   it('sets data on next, error and complete', () => {
@@ -34,13 +38,12 @@ describe('querySnapshotQueryClientObserver', () => {
     })
 
     observer.complete()
-    expect(client.setQueryData).toHaveBeenCalledWith(queryKey, {
-      empty: true,
-      size: 0,
-      isLoading: false,
-      hasError: false,
-      disabled: true,
-      data: [],
+    expect(addBreadcrumb).toHaveBeenCalledWith({
+      level: 'debug',
+      message: 'Document snapshot query completed',
+      data: {
+        queryKey,
+      },
     })
   })
 })

--- a/packages/react-kitchen-sink/src/react-query/observers/documentSnapshotQueryClientObserver.ts
+++ b/packages/react-kitchen-sink/src/react-query/observers/documentSnapshotQueryClientObserver.ts
@@ -1,5 +1,5 @@
 import { type DocumentData } from '@firebase/firestore'
-import { captureException } from '@sentry/react'
+import { addBreadcrumb, captureException } from '@sentry/react'
 import { type QueryClient, type QueryKey } from '@tanstack/react-query'
 import { type DocumentSnapshotState } from '@valian/rxjs-firebase'
 import { type Observer } from 'rxjs'
@@ -23,10 +23,12 @@ export const documentSnapshotQueryClientObserver = <
     })
   },
   complete: () => {
-    client.setQueryData<DocumentSnapshotState<AppModelType, DbModelType>>(queryKey, {
-      isLoading: false,
-      hasError: false,
-      disabled: true,
+    addBreadcrumb({
+      level: 'debug',
+      message: 'Query snapshot query completed',
+      data: {
+        queryKey,
+      },
     })
   },
 })

--- a/packages/react-kitchen-sink/src/react-query/observers/querySnapshotQueryClientObserver.ts
+++ b/packages/react-kitchen-sink/src/react-query/observers/querySnapshotQueryClientObserver.ts
@@ -1,5 +1,5 @@
 import { type DocumentData } from '@firebase/firestore'
-import { captureException } from '@sentry/react'
+import { addBreadcrumb, captureException } from '@sentry/react'
 import { type QueryClient, type QueryKey } from '@tanstack/react-query'
 import { type QuerySnapshotState } from '@valian/rxjs-firebase'
 import { type Observer } from 'rxjs'
@@ -26,13 +26,12 @@ export const querySnapshotQueryClientObserver = <
     })
   },
   complete: () => {
-    client.setQueryData<QuerySnapshotState<AppModelType, DbModelType>>(queryKey, {
-      empty: true,
-      size: 0,
-      isLoading: false,
-      hasError: false,
-      disabled: true,
-      data: [],
+    addBreadcrumb({
+      level: 'debug',
+      message: 'Document snapshot query completed',
+      data: {
+        queryKey,
+      },
     })
   },
 })

--- a/packages/react-kitchen-sink/src/react-query/querySnapshotQueryOptions.ts
+++ b/packages/react-kitchen-sink/src/react-query/querySnapshotQueryOptions.ts
@@ -69,7 +69,7 @@ export const querySnapshotQueryOptions = <
       snapshotManager.querySnapshotSubjectFactory(query, snapshotOptions, listener),
       props,
     ),
-    staleTime: Infinity,
+    staleTime: () => (snapshotManager.isSnapshotAlive(props.queryKey) ? 'static' : 0),
     retry: false,
     gcTime: 10_000,
     initialData: undefined,

--- a/packages/react-kitchen-sink/src/react-query/schemaQuerySnapshotQueryOptions.ts
+++ b/packages/react-kitchen-sink/src/react-query/schemaQuerySnapshotQueryOptions.ts
@@ -78,7 +78,7 @@ export const schemaQuerySnapshotQueryOptions = <
       snapshotManager.schemaQuerySnapshotSubjectFactory(factory, query, snapshotOptions, listener),
       props,
     ),
-    staleTime: Infinity,
+    staleTime: () => (snapshotManager.isSnapshotAlive(props.queryKey) ? 'static' : 0),
     retry: false,
     gcTime: 10_000,
     ...props,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a way to check if a Firestore snapshot is currently active.
- Improvements
  - Query staleness now adapts dynamically: remains static when a snapshot is alive, refetches immediately when not.
- Observability
  - Emits debug breadcrumbs when snapshot streams complete for better diagnostics.
- Tests
  - Added unit tests for snapshot liveness and staleness behavior across document, query, and schema query options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->