### PR TITLE
feat: add callback to firebaseAuthSubscription

### DIFF
--- a/packages/react-kitchen-sink/src/auth/__tests__/useAuth.test.ts
+++ b/packages/react-kitchen-sink/src/auth/__tests__/useAuth.test.ts
@@ -78,4 +78,55 @@ describe('useAuth and firebaseAuthSubscription', () => {
 
     sub.unsubscribe()
   })
+
+  it('calls onAuthStateChanged callback when user is null', () => {
+    const onAuthStateChanged = vi.fn()
+    vi.mocked(authState).mockReturnValue(of(null) as Observable<User | null>)
+
+    const sub = firebaseAuthSubscription(app, onAuthStateChanged)
+
+    expect(onAuthStateChanged).toHaveBeenCalledWith({ initialized: true, user: null })
+
+    sub.unsubscribe()
+  })
+
+  it('calls onAuthStateChanged callback when user is authenticated', () => {
+    const onAuthStateChanged = vi.fn()
+    const fakeUser = {
+      uid: 'uid-123',
+      email: 'user@example.com',
+      displayName: 'User Name',
+    } as unknown as User
+
+    vi.mocked(authState).mockReturnValue(of(fakeUser) as Observable<User | null>)
+
+    const sub = firebaseAuthSubscription(app, onAuthStateChanged)
+
+    expect(onAuthStateChanged).toHaveBeenCalledWith({ initialized: true, user: fakeUser })
+
+    sub.unsubscribe()
+  })
+
+  it('calls onAuthStateChanged callback when error occurs', () => {
+    const onAuthStateChanged = vi.fn()
+    const err = new Error('boom')
+    vi.mocked(authState).mockReturnValue(throwError(() => err) as Observable<User | null>)
+
+    const sub = firebaseAuthSubscription(app, onAuthStateChanged)
+
+    expect(onAuthStateChanged).toHaveBeenCalledWith({ initialized: false, user: null })
+
+    sub.unsubscribe()
+  })
+
+  it('works without onAuthStateChanged callback (undefined)', () => {
+    vi.mocked(authState).mockReturnValue(of(null) as Observable<User | null>)
+
+    const sub = firebaseAuthSubscription(app)
+
+    expect(useAuth.getState()).toEqual({ initialized: true, user: null })
+    expect(setSentryUser).toHaveBeenCalledWith(null)
+
+    sub.unsubscribe()
+  })
 })

--- a/packages/react-kitchen-sink/src/auth/useAuth.ts
+++ b/packages/react-kitchen-sink/src/auth/useAuth.ts
@@ -22,7 +22,10 @@ export const useAuth = create<FirebaseAuthContextValue>(() => ({
   user: null,
 }))
 
-export const firebaseAuthSubscription = (app: ReturnType<typeof initializeApp>) =>
+export const firebaseAuthSubscription = (
+  app: ReturnType<typeof initializeApp>,
+  onAuthStateChanged?: (state: FirebaseAuthContextValue) => void,
+) =>
   authState(getAuth(app))
     .pipe(
       map((user) => ({ initialized: true, user }) as FirebaseAuthContextValue),
@@ -42,4 +45,5 @@ export const firebaseAuthSubscription = (app: ReturnType<typeof initializeApp>) 
             }
           : null,
       )
+      onAuthStateChanged?.(state)
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth subscription accepts an optional callback to receive real-time authentication state updates (initialized, user present/absent, error). No breaking changes.

* **Tests**
  * Added tests covering null user, authenticated user, error handling, and behavior when no callback is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->