### PR TITLE
chore: explicit exclude external to fix tsdown build

### DIFF
--- a/packages/react-kitchen-sink/tsdown.config.mjs
+++ b/packages/react-kitchen-sink/tsdown.config.mjs
@@ -6,4 +6,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   target: 'es2020',
   fixedExtension: true,
+  external: [/^firebase\//, /^@firebase\//, /^zustand\//],
 })

--- a/packages/rxjs-firebase/tsdown.config.mjs
+++ b/packages/rxjs-firebase/tsdown.config.mjs
@@ -6,4 +6,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   target: 'es2020',
   fixedExtension: true,
+  external: [/^firebase\//, /^@firebase\//],
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Externalized Firebase and Zustand from the build in the React kitchen-sink package.
  - Externalized Firebase from the build in the RxJS Firebase package.
  - Result: smaller bundles and faster installs/builds due to excluding these dependencies from bundling.
  - Note: Ensure Firebase (and Zustand where applicable) are installed in consuming projects, as they are now treated as external peer dependencies.
  - No functional changes to runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->