### PR TITLE
fix: enabled query should not use refFn

### DIFF
--- a/packages/react-kitchen-sink/src/react-query/documentSnapshotQueryOptions.ts
+++ b/packages/react-kitchen-sink/src/react-query/documentSnapshotQueryOptions.ts
@@ -66,7 +66,7 @@ export const documentSnapshotQueryOptions = <
         DbModelType
       >)
     },
-    enabled: refFn ? !!refFn() : !!ref,
+    enabled: !!ref,
     gcTime: 10_000,
     ...props,
     meta: {

--- a/packages/react-kitchen-sink/src/react-query/schemaDocumentSnapshotQueryOptions.ts
+++ b/packages/react-kitchen-sink/src/react-query/schemaDocumentSnapshotQueryOptions.ts
@@ -48,5 +48,6 @@ export const schemaDocumentSnapshotQueryOptions = <
   documentSnapshotQueryOptions({
     ...(id ? { refFn: () => factory.read.doc(id, snapshotOptions) } : {}),
     snapshotOptions,
+    enabled: !!id,
     ...props,
   })


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Fixed a bug where the `enabled` property was prematurely calling `refFn()` to determine if a query should run. The `enabled` property in React Query should be based on static values and not execute functions with potential side effects.

- In `documentSnapshotQueryOptions`, changed from `enabled: refFn ? !!refFn() : !!ref` to `enabled: !!ref`
- In `schemaDocumentSnapshotQueryOptions`, added explicit `enabled: !!id` control

This aligns with the pattern used in `querySnapshotQueryOptions` (line 67) which uses `enabled: !!query` without calling `queryFn()`. The fix ensures lazy evaluation of `refFn` only when the query actually executes.

### Confidence Score: 5/5

- This PR is safe to merge with no risk - it fixes a clear bug with the correct solution
- The change correctly fixes a bug where `refFn()` was being called prematurely in the `enabled` property. The fix aligns with established patterns in the codebase (`querySnapshotQueryOptions` uses the same approach) and existing tests validate the behavior. No breaking changes or side effects expected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/react-kitchen-sink/src/react-query/documentSnapshotQueryOptions.ts | 5/5 | Fixed `enabled` logic to avoid calling `refFn()` prematurely - now only checks `!!ref` |
| packages/react-kitchen-sink/src/react-query/schemaDocumentSnapshotQueryOptions.ts | 5/5 | Added explicit `enabled: !!id` to control query execution based on ID presence |

</details>

