### PR TITLE
fix(react-kitchen-sink): enable query when refFn is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ junit.xml
 !/src/
 /lib
 /dist/
+.claude/settings.local.json

--- a/packages/react-kitchen-sink/src/react-query/__tests__/documentSnapshotQueryOptions.test.ts
+++ b/packages/react-kitchen-sink/src/react-query/__tests__/documentSnapshotQueryOptions.test.ts
@@ -45,6 +45,22 @@ describe('documentSnapshotQueryOptions', () => {
     })
   })
 
+  it('should return a snapshot when refFn is provided', async () => {
+    const subject = new Subject<DocumentSnapshot>()
+    vi.mocked(fromDocumentRef).mockReturnValueOnce(subject)
+
+    const ref = stub<DocumentReference>()
+    const options = documentSnapshotQueryOptions({ refFn: () => ref, queryKey: ['doc-refFn'] })
+    const promise = queryClient.fetchQuery(options)
+
+    const snapshot = mock<DocumentSnapshot>()
+    snapshot.exists.mockReturnValue(true)
+    snapshot.data.mockReturnValue({ foo: 'bar' })
+    subject.next(snapshot)
+
+    await expect(promise).resolves.toMatchObject({ disabled: false, exists: true })
+  })
+
   it('should return disabled state when ref is null', async () => {
     const options = documentSnapshotQueryOptions({ ref: null, enabled: true, queryKey: ['doc-empty'] })
     await expect(queryClient.fetchQuery(options)).resolves.toMatchObject({ disabled: true })

--- a/packages/react-kitchen-sink/src/react-query/documentSnapshotQueryOptions.ts
+++ b/packages/react-kitchen-sink/src/react-query/documentSnapshotQueryOptions.ts
@@ -66,7 +66,7 @@ export const documentSnapshotQueryOptions = <
         DbModelType
       >)
     },
-    enabled: !!ref,
+    enabled: !!(ref ?? refFn),
     gcTime: 10_000,
     ...props,
     meta: {


### PR DESCRIPTION
## Summary

`documentSnapshotQueryOptions` computed `enabled: !!ref`, which always evaluates to `false` when only `refFn` is provided. This permanently disabled any query going through `schemaSingleDocumentSnapshotQueryOptions`, which exclusively uses `refFn`.

## Changes

- **fix(react-kitchen-sink):** change `enabled` default from `!!ref` to `!!(ref ?? refFn)` so queries are enabled when a lazy reference function is supplied
- **chore:** add `.claude/settings.local.json` to `.gitignore`
